### PR TITLE
Unit tests that verify correct Diff() behavior on Kubernetes Resources

### DIFF
--- a/THIRD_PARTY_LICENSES.txt
+++ b/THIRD_PARTY_LICENSES.txt
@@ -1,10 +1,11 @@
 github.com/verrazzano/pkg
 -------- Copyrights
-Copyright (c) 2020 Oracle America, Inc. and its affiliates. 
+Copyright (c) 2021 Oracle America, Inc. and its affiliates.
+Copyright (c) 2021, Oracle and/or its affiliates.
 Copyright (C) 2021, Oracle and/or its affiliates.
 
 -------- License
-Copyright (c) 2020 Oracle America, Inc. and its affiliates. 
+Copyright (c) 2021 Oracle America, Inc. and its affiliates.
 
 The Universal Permissive License (UPL), Version 1.0
 
@@ -85,4 +86,4 @@ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ATTRIBUTION-HELPER-GENERATED:
-License file based on go.mod with md5 sum: ceeb284685d01c120a0c982ef88a56e7
+License file based on go.mod with md5 sum: ad8ff9601475c864dcd8d768548e6017

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,10 @@ require (
 	github.com/google/go-cmp v0.5.0
 	github.com/stretchr/testify v1.6.1
 	k8s.io/api v0.19.0
+	k8s.io/apimachinery v0.21.1
 )
 
-replace k8s.io/api => k8s.io/api v0.18.6
+replace (
+	k8s.io/api => k8s.io/api v0.18.6
+	k8s.io/apimachinery => k8s.io/apimachinery v0.18.6
+)


### PR DESCRIPTION
Adds unit tests to verify that the Diff() function works correctly on Kubernetes Resources - namely, that it will treat equivalent Resources, but specified in different units, as equal.

A new import has been added for k8s.io/apimachinery 0.18.6 - this is the same version already approved internally and used in https://github.com/verrazzano/verrazzano: https://github.com/verrazzano/verrazzano/blob/master/go.mod#L44